### PR TITLE
Added Drupal State API to example nodata list.

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -43,6 +43,9 @@ nodata:
   - search_dataset
   - search_index
   - search_total
+  # Drupal State API storage.
+  - key_value
+  - key_value_expire
 
 ignore:
   - __ACQUIA_MONITORING__


### PR DESCRIPTION
## Motivation

From the docs - https://www.drupal.org/docs/8/api/state-api/overview

> * It is specific to an individual environment.
> * You will never want to deploy it between environments.
> * You can reset a system, losing all state. Its configuration remains.

The work I'm doing on vault_key_aws requires storing leases in the state api, so this would assist avoiding sending AWS credentials around the place.